### PR TITLE
Issue #61 - Update the installation process description in our fork of foundry book

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,17 @@
 name: deploy
-on: [push]
+on:
+ - push
+ - workflow_dispatch
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pages: write
+      id-token: write
       deployments: write
-    name: Deploy to Cloudflare Pages
+    name: Deploy to GH Pages
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -23,11 +27,13 @@ jobs:
       - name: Build book
         run: mdbook build
 
-      - name: Publish
-        uses: cloudflare/pages-action@v1.4.0
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: foundry-book
-          directory: book
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          # Upload entire repository
+          path: 'book'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -10,5 +10,5 @@ jobs:
     steps:
       - uses: actions/add-to-project@main
         with:
-          project-url: https://github.com/orgs/foundry-rs/projects/1
+          project-url: https://github.com/orgs/paritytech/projects/1
           github-token: ${{ secrets.GH_PROJECTS_TOKEN }}


### PR DESCRIPTION
###Description
Provides the solution for steps reported in [paritytech/foundry#61](https://github.com/paritytech/foundry/issues/61), where we need to create an on-demand CI Workflow for Releasing foundry tool binaries for forge and cast for various OS runtime flavours compatible with revive compiler. This also includes the installer script to install one of the generated binaries, again based out of users runtime and Setting up a runbook with installation process for foundry binary

###Changes
Fork of our version of Foundry book. Initial setup.  